### PR TITLE
Added info on installing proj

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A tool to convert shapefiles to SVG.
 
 ## Installation
 
-1) [Download and install Go](https://golang.org/dl/); then,
+1) [Download and install Go](https://golang.org/dl/) and [proj](https://proj.org/en/9.3/install.html); then,
 2) Run `go install github.com/everystreet/shp2svg/cmd/shp2svg@latest`.
 
 ## Usage


### PR DESCRIPTION
When trying ton install, I came across this error:

```
# github.com/everystreet/go-proj/v6/cproj
../go/pkg/mod/github.com/everystreet/go-proj/v6@v6.0.0/cproj/cgo_helpers.go:8:10: fatal error: 'proj.h' file not found
#include "proj.h"
         ^~~~~~~~
1 error generated.
```

Turns out I needed to also install `proj` before I could intsall this. Adding this info to the docs